### PR TITLE
DEVPROD-20765 fix: Use yarn.lock for Drone builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,7 @@ platform:
 trigger:
   branch:
     - main
+    - DEVPROD-20765-fix
 
 steps:
   - name: publish

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,6 @@ platform:
 trigger:
   branch:
     - main
-    - DEVPROD-20765-fix
 
 steps:
   - name: publish

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM --platform=linux/amd64 node:22-alpine
 WORKDIR /app
 COPY package.json ./
+COPY yarn.lock ./
 RUN yarn install
 COPY . .
 RUN yarn build

--- a/README.md
+++ b/README.md
@@ -142,3 +142,9 @@ Launches a local Mastra server at `http://localhost:4111` for agent testing.
 * **Workflows**: Add workflows to `src/mastra/workflows`. Workflows define multi-step logic that agents can follow.
 
 All agents and workflows should be registered in `src/mastra/index.ts`.
+
+## Deployment
+
+### Staging Deploys
+
+To deploy your changes to Sage's staging environment, make changes on a new branch. Update the .drone.yml's `trigger` field to include your branch name, commit, and push up to GitHub. A Drone build will be kicked off automatically.


### PR DESCRIPTION
DEVPROD-20765

### Description
<!-- add description, context, thought process, etc -->
Using a lockfile should make Drone package installation more reliable and faster.

### Testing
First commit below shows successful `publish` stage