### PR TITLE
DEVPROD-19212 Add more robust authentication to sage

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,7 @@ platform:
 trigger:
   branch:
     - main
+    - DEVPROD-19212
 
 steps:
   - name: publish

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,6 @@ platform:
 trigger:
   branch:
     - main
-    - DEVPROD-19212
 
 steps:
   - name: publish

--- a/env-example
+++ b/env-example
@@ -15,8 +15,6 @@ OTEL_COLLECTOR_URL=
 
 # Evergreen Configuration
 EVERGREEN_GRAPHQL_ENDPOINT=http://localhost:9090/mcp/graphql/query
-EVERGREEN_API_USER=sage
-EVERGREEN_API_KEY=mysecret
 END_USER_HEADER_ID=sage
 
 # MongoDB Configuration

--- a/src/api-server/routes/completions/parsley/addMessage.ts
+++ b/src/api-server/routes/completions/parsley/addMessage.ts
@@ -1,4 +1,4 @@
-import { LanguageModelV2Usage } from '@ai-sdk/provider';
+import { RuntimeContext } from '@mastra/core/runtime-context';
 import { Request, Response } from 'express';
 import z from 'zod';
 import { mastra } from 'mastra';
@@ -108,8 +108,26 @@ const addMessageRoute = async (
         ? memoryOptions.thread
         : memoryOptions.thread.id;
 
+    const runtimeContext = new RuntimeContext();
+
+    const apiUser = req.headers['api-user'] as string | undefined;
+    const apiKey = req.headers['api-key'] as string | undefined;
+
+    if (apiUser) {
+      runtimeContext.set('apiUser', apiUser);
+    }
+    if (apiKey) {
+      runtimeContext.set('apiKey', apiKey);
+    }
+
+    const userID = req.headers['end-user-header-id'] as string | undefined;
+    if (userID) {
+      runtimeContext.set('userID', userID);
+    }
+
     const result = await agent.generate(messageData.message, {
       memory: memoryOptions,
+      runtimeContext,
     });
 
     res.json({

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -128,8 +128,6 @@ export const validateConfig = (): string[] | undefined => {
     'AZURE_OPENAI_API_KEY',
     'AZURE_OPENAI_ENDPOINT',
     'EVERGREEN_GRAPHQL_ENDPOINT',
-    'EVERGREEN_API_USER',
-    'EVERGREEN_API_KEY',
   ];
 
   const errors: string[] = [];

--- a/src/mastra/tools/evergreen/graphql/evergreenClient.ts
+++ b/src/mastra/tools/evergreen/graphql/evergreenClient.ts
@@ -1,19 +1,9 @@
 import { config } from '../../../../config';
 import { GraphQLClient } from '../../../../utils/graphql/client';
 
-export const createEvergreenClient = (apiUser?: string, apiKey?: string) =>
-  new GraphQLClient(
-    config.evergreen.graphqlEndpoint,
-    config.evergreen.userIDHeader,
-    {
-      ...(apiUser && { 'Api-User': apiUser }),
-      ...(apiKey && { 'Api-Key': apiKey }),
-    }
-  );
-
-const evergreenClient = createEvergreenClient(
-  config.evergreen.apiUser,
-  config.evergreen.apiKey
+const evergreenClient = new GraphQLClient(
+  config.evergreen.graphqlEndpoint,
+  config.evergreen.userIDHeader
 );
 
 export default evergreenClient;

--- a/src/mastra/tools/evergreen/graphql/evergreenClient.ts
+++ b/src/mastra/tools/evergreen/graphql/evergreenClient.ts
@@ -1,13 +1,19 @@
 import { config } from '../../../../config';
 import { GraphQLClient } from '../../../../utils/graphql/client';
 
-const evergreenClient = new GraphQLClient(
-  config.evergreen.graphqlEndpoint,
-  config.evergreen.userIDHeader,
-  {
-    'Api-User': config.evergreen.apiUser,
-    'Api-Key': config.evergreen.apiKey,
-  }
+export const createEvergreenClient = (apiUser?: string, apiKey?: string) =>
+  new GraphQLClient(
+    config.evergreen.graphqlEndpoint,
+    config.evergreen.userIDHeader,
+    {
+      ...(apiUser && { 'Api-User': apiUser }),
+      ...(apiKey && { 'Api-Key': apiKey }),
+    }
+  );
+
+const evergreenClient = createEvergreenClient(
+  config.evergreen.apiUser,
+  config.evergreen.apiKey
 );
 
 export default evergreenClient;

--- a/src/mastra/utils/graphql/createGraphQLTool.ts
+++ b/src/mastra/utils/graphql/createGraphQLTool.ts
@@ -48,9 +48,21 @@ export const createGraphQLTool = <
         );
       }
 
+      const apiUser = runtimeContext.get('apiUser') as string | undefined;
+      const apiKey = runtimeContext.get('apiKey') as string | undefined;
+
+      const headers: Record<string, string> = {};
+      if (apiUser) {
+        headers['Api-User'] = apiUser;
+      }
+      if (apiKey) {
+        headers['Api-Key'] = apiKey;
+      }
+
       try {
         const result = await client.executeQuery<TResult>(query, context, {
           userID: userID ?? '',
+          headers,
         });
         return result;
       } catch (error) {


### PR DESCRIPTION
DEVPROD-19212


### Description
Adds better authentication to sage where users are only able to ask about evergreen resources they have access to, and they also cannot fetch conversations from anyone else but their own.

### Testing
Tested in staging that the graphql permissions layer is respected, and that users cannot GET conversation threads that are not their own.


