### PR TITLE
DEVPROD-21129 Ensure dotenv resolves the correct path when running mastra dev

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,11 +1,12 @@
 import dotenvFlow from 'dotenv-flow';
 import path from 'path';
 
-const isMastraOutput = process.cwd().includes('.mastra');
+const cwd = process.cwd();
+const isMastraOutput =
+  path.basename(cwd) === 'output' &&
+  path.basename(path.dirname(cwd)) === '.mastra';
 dotenvFlow.config({
-  path: isMastraOutput
-    ? path.resolve(process.cwd(), '..', '..')
-    : process.cwd(),
+  path: isMastraOutput ? path.resolve(cwd, '..', '..') : cwd,
   node_env: process.env.DEPLOYMENT_ENV || 'local',
 });
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,6 +1,11 @@
 import dotenvFlow from 'dotenv-flow';
+import path from 'path';
 
+const isMastraOutput = process.cwd().includes('.mastra');
 dotenvFlow.config({
+  path: isMastraOutput
+    ? path.resolve(process.cwd(), '..', '..')
+    : process.cwd(),
   node_env: process.env.DEPLOYMENT_ENV || 'local',
 });
 


### PR DESCRIPTION
DEVPROD-21129


### Description
The dotenv-flow config was not working due to mastra running out of .mastra/output directory. This pr adds a small check to determine if we are in the mastra directory if so it will ensure we properly import the value 

### Testing
<!-- add a description of how you tested it -->


