### PR TITLE
DEVPROD-21436 Add login route

### DIFF
--- a/src/api-server/index.ts
+++ b/src/api-server/index.ts
@@ -9,7 +9,7 @@ import {
   httpLoggingMiddleware,
   errorLoggingMiddleware,
 } from './middlewares/logging';
-import { completionsRoute } from './routes';
+import { completionsRoute, loginRoute } from './routes';
 import healthRoute from './routes/health';
 import rootRoute from './routes/root';
 
@@ -44,6 +44,7 @@ class SageServer {
     this.app.get('/', rootRoute);
     this.app.get('/health', healthRoute);
     this.app.use('/completions', completionsRoute);
+    this.app.use('/login', loginRoute);
   }
 
   private setupErrorHandling() {

--- a/src/api-server/routes/index.ts
+++ b/src/api-server/routes/index.ts
@@ -1,5 +1,6 @@
 import completionsRoute from './completions';
 import healthRoute from './health';
+import loginRoute from './login';
 import rootRoute from './root';
 
-export { healthRoute, rootRoute, completionsRoute };
+export { healthRoute, rootRoute, completionsRoute, loginRoute };

--- a/src/api-server/routes/login.ts
+++ b/src/api-server/routes/login.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express';
 
 /**
- * Login route This route primarily serves to provide a success message to the client after a successful login
+ * Login route. This route primarily serves to provide a success message to the client after a successful login
  * Login is handled by the kanopy oidc login flow and a user will be redirected to this route after a successful login
  * @param req - Express request object
  * @param res - Express response object

--- a/src/api-server/routes/login.ts
+++ b/src/api-server/routes/login.ts
@@ -1,0 +1,13 @@
+import { Request, Response } from 'express';
+
+/**
+ * Login route This route primarily serves to provide a success message to the client after a successful login
+ * Login is handled by the kanopy oidc login flow and a user will be redirected to this route after a successful login
+ * @param req - Express request object
+ * @param res - Express response object
+ */
+const loginRoute = (req: Request, res: Response) => {
+  res.send({ message: 'Logged in successfully, you may close this window' });
+};
+
+export default loginRoute;


### PR DESCRIPTION
DEVPROD-21436


### Description
Adds a new login route to the Sage API. This is for initial user login.

Since Kanopy blocks all Sage requests, we're using a special login flow. When a user clicks a button in the Parsley app, a new tab opens and redirects them to the Kanopy authentication page. After the user logs in, they'll be redirected to a success page.

I chose not to redirect the user back to Parsley to avoid an extra log download. Instead, Parsley will regularly check the login route to confirm the user's successful authentication. Once confirmed, a chat pane will appear.

### Testing


https://github.com/user-attachments/assets/d592f8d6-24f9-4266-a8df-6bb44beed648




