### PR TITLE
DEVPROD-21581 Improve log file url calculation reliability 

### DIFF
--- a/src/api-server/routes/completions/parsley/chat.ts
+++ b/src/api-server/routes/completions/parsley/chat.ts
@@ -7,7 +7,6 @@ import {
 import { Request, Response } from 'express';
 import z from 'zod';
 import { logMetadataSchema } from 'constants/parsley/logMetadata';
-import { generateLogURL } from 'constants/parsley/logURLTemplates';
 import { mastra } from 'mastra';
 import { createParsleyRuntimeContext } from 'mastra/memory/parsley/runtimeContext';
 import { logger } from 'utils/logger';

--- a/src/api-server/routes/completions/parsley/chat.ts
+++ b/src/api-server/routes/completions/parsley/chat.ts
@@ -47,12 +47,16 @@ const chatRoute = async (
     requestId: req.requestId,
   });
 
-  const { data: messageData, success: messageSuccess } =
-    addMessageInputSchema.safeParse(req.body);
+  const {
+    data: messageData,
+    error: messageError,
+    success: messageSuccess,
+  } = addMessageInputSchema.safeParse(req.body);
   if (!messageSuccess) {
     logger.error('Invalid request body', {
       requestId: req.requestId,
       body: req.body,
+      error: messageError,
     });
     res.status(400).json({ message: 'Invalid request body' });
     return;

--- a/src/constants/parsley/logMetadata.ts
+++ b/src/constants/parsley/logMetadata.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { LogTypes } from 'types/parsley';
-import { TaskLogOrigin } from 'types/task';
+import { LogTypes } from '../../types/parsley';
+import { TaskLogOrigin } from '../../types/task';
 
 const evergreenTaskFileSchema = z.object({
   log_type: z.literal(LogTypes.EVERGREEN_TASK_FILE),

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -424,11 +424,13 @@ export enum BannerTheme {
 
 export type BetaFeatures = {
   __typename?: 'BetaFeatures';
-  spruceWaterfallEnabled: Scalars['Boolean']['output'];
+  parsleyAIEnabled?: Maybe<Scalars['Boolean']['output']>;
+  spruceWaterfallEnabled?: Maybe<Scalars['Boolean']['output']>;
 };
 
 export type BetaFeaturesInput = {
-  spruceWaterfallEnabled: Scalars['Boolean']['input'];
+  parsleyAIEnabled?: InputMaybe<Scalars['Boolean']['input']>;
+  spruceWaterfallEnabled?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export enum BootstrapMethod {
@@ -5022,8 +5024,9 @@ export type TaskTestsQueryVariables = Exact<{
   execution?: InputMaybe<Scalars['Int']['input']>;
   pageNum?: InputMaybe<Scalars['Int']['input']>;
   limitNum?: InputMaybe<Scalars['Int']['input']>;
-  statusList: Array<Scalars['String']['input']>;
+  statusList?: InputMaybe<Array<Scalars['String']['input']>>;
   sort?: InputMaybe<Array<TestSortOptions>>;
+  groupId?: InputMaybe<Scalars['String']['input']>;
   testName: Scalars['String']['input'];
 }>;
 

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -5027,7 +5027,7 @@ export type TaskTestsQueryVariables = Exact<{
   statusList?: InputMaybe<Array<Scalars['String']['input']>>;
   sort?: InputMaybe<Array<TestSortOptions>>;
   groupId?: InputMaybe<Scalars['String']['input']>;
-  testName: Scalars['String']['input'];
+  testName?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 export type TaskTestsQuery = {

--- a/src/mastra/agents/planning/sageThinkingAgent.ts
+++ b/src/mastra/agents/planning/sageThinkingAgent.ts
@@ -39,6 +39,7 @@ export const sageThinkingAgent: Agent = new Agent({
      - Use for: Analyzing log files or text content when you have the actual content
      - Accepts: file path (local), URL (direct link to content), or raw text string
      - Does NOT: Fetch from Evergreen (use evergreenAgent for that first)
+     - When providing a url, it should be a direct link to the log content. Do not make any changes to the url.
   
   3. **questionClassifierAgent**: Classifies user questions to determine appropriate response strategy
      - Use for: Understanding user intent and deciding which tools to use

--- a/src/mastra/tools/evergreen/getTaskTests.ts
+++ b/src/mastra/tools/evergreen/getTaskTests.ts
@@ -18,7 +18,7 @@ const GET_TASK_TESTS = gql`
     $statusList: [String!]
     $sort: [TestSortOptions!]
     $groupId: String
-    $testName: String!
+    $testName: String
   ) {
     task(taskId: $id, execution: $execution) {
       id
@@ -66,7 +66,7 @@ const getTaskTestsInputSchema = z.object({
   statusList: z.array(StatusEnum).default([]).optional(),
   groupId: z.string().optional(),
   sort: z.array(TestSortOptionsSchema).optional(),
-  testName: z.string(),
+  testName: z.string().optional(),
 });
 
 const getTaskTestsOutputSchema = z.object({

--- a/src/mastra/tools/evergreen/getTaskTests.ts
+++ b/src/mastra/tools/evergreen/getTaskTests.ts
@@ -15,8 +15,9 @@ const GET_TASK_TESTS = gql`
     $execution: Int
     $pageNum: Int
     $limitNum: Int
-    $statusList: [String!]!
+    $statusList: [String!]
     $sort: [TestSortOptions!]
+    $groupId: String
     $testName: String!
   ) {
     task(taskId: $id, execution: $execution) {
@@ -28,6 +29,7 @@ const GET_TASK_TESTS = gql`
           page: $pageNum
           limit: $limitNum
           statuses: $statusList
+          groupID: $groupId
           testName: $testName
         }
       ) {
@@ -54,14 +56,15 @@ const TestSortOptionsSchema = z.object({
   sortBy: z.nativeEnum(TestSortCategory),
 });
 
-const StatusEnum = z.enum(['fail', 'pass']);
+const StatusEnum = z.enum(['fail', 'pass', 'timeout', 'silentfail']);
 
 const getTaskTestsInputSchema = z.object({
   id: z.string(),
   execution: z.number().optional(),
   pageNum: z.number().optional(),
   limitNum: z.number().optional(),
-  statusList: z.array(StatusEnum),
+  statusList: z.array(StatusEnum).default([]).optional(),
+  groupId: z.string().optional(),
   sort: z.array(TestSortOptionsSchema).optional(),
   testName: z.string(),
 });

--- a/src/mastra/workflows/evergreen/getLogFileUrlWorkflow.ts
+++ b/src/mastra/workflows/evergreen/getLogFileUrlWorkflow.ts
@@ -1,0 +1,172 @@
+import { createWorkflow, createStep } from '@mastra/core';
+import { z } from 'zod';
+import { logMetadataSchema } from '../../../constants/parsley/logMetadata';
+import {
+  constructEvergreenTaskLogURL,
+  getEvergreenTaskFileURL,
+} from '../../../constants/parsley/logURLTemplates';
+import { LogTypes } from '../../../types/parsley';
+import { getTaskTestsTool } from '../../tools/evergreen';
+
+const step1ValidateLogFileUrl = createStep({
+  id: 'validate-log-file-url',
+  description: 'Validate the log file url',
+  inputSchema: z.object({
+    logMetadata: logMetadataSchema,
+  }),
+  outputSchema: z.object({
+    logType: z.nativeEnum(LogTypes),
+    logMetadata: logMetadataSchema,
+  }),
+  execute: async ({ inputData }) => {
+    const { logMetadata } = inputData;
+    return {
+      logType: logMetadata.log_type,
+      logMetadata: logMetadata,
+    };
+  },
+});
+
+const step2SimpleLogFileUrl = createStep({
+  id: 'simple-log-file-url',
+  description: 'Get the log file url from a template string',
+  inputSchema: z.object({
+    logMetadata: logMetadataSchema,
+    logType: z.nativeEnum(LogTypes),
+  }),
+  outputSchema: z.object({
+    logFileUrl: z.string(),
+  }),
+  execute: async ({ inputData }) => {
+    const { logMetadata } = inputData;
+    switch (logMetadata.log_type) {
+      case LogTypes.EVERGREEN_TASK_FILE:
+        return {
+          logFileUrl: getEvergreenTaskFileURL(
+            logMetadata.task_id,
+            logMetadata.execution,
+            logMetadata.fileName
+          ),
+        };
+      case LogTypes.EVERGREEN_TASK_LOGS:
+        return {
+          logFileUrl: constructEvergreenTaskLogURL(
+            logMetadata.task_id,
+            logMetadata.execution,
+            logMetadata.origin,
+            {
+              text: true,
+            }
+          ),
+        };
+      default:
+        throw new Error('Unsupported log type for this workflow');
+    }
+  },
+});
+
+const getTestResultsStep = createStep({
+  id: 'get-test-results',
+  description: 'Get the test results for a test log',
+  inputSchema: z.object({
+    logMetadata: logMetadataSchema,
+    logType: z.nativeEnum(LogTypes),
+  }),
+  outputSchema: z.object({
+    getTestResultsStepOutput: getTaskTestsTool.outputSchema,
+    testId: z.string(),
+    groupId: z.string().optional(),
+  }),
+  execute: async ({ inputData, runtimeContext }) => {
+    const { logMetadata } = inputData;
+    if (logMetadata.log_type !== LogTypes.EVERGREEN_TEST_LOGS) {
+      throw new Error('Log metadata is not a test log');
+    }
+    console.log('filters on', logMetadata.test_id, logMetadata.group_id);
+    const getTestResultsStepOutput = await getTaskTestsTool.execute({
+      context: {
+        id: logMetadata.task_id,
+        execution: logMetadata.execution,
+        groupId: logMetadata.group_id,
+      },
+      runtimeContext: runtimeContext,
+    });
+    return {
+      getTestResultsStepOutput: getTestResultsStepOutput,
+      testId: logMetadata.test_id,
+      groupId: logMetadata.group_id,
+    };
+  },
+});
+
+const getFinalTestLogUrl = createStep({
+  id: 'get-final-test-log-url',
+  description: 'Get the final test log url',
+  inputSchema: getTestResultsStep.outputSchema,
+  outputSchema: z.object({
+    logFileUrl: z.string(),
+  }),
+  execute: async ({ inputData }) => {
+    const { getTestResultsStepOutput, testId } = inputData;
+    if (!getTestResultsStepOutput) {
+      throw new Error('Task is not defined');
+    }
+    let logFileUrl = '';
+    getTestResultsStepOutput.task?.tests.testResults.forEach(testResult => {
+      if (testResult.id === testId) {
+        logFileUrl = testResult.logs.urlRaw ?? '';
+      }
+    });
+    if (logFileUrl === '') {
+      throw new Error('Test log url not found');
+    }
+    return {
+      logFileUrl: logFileUrl,
+    };
+  },
+});
+
+const getDynamicTestLogUrlWorkflow = createWorkflow({
+  id: 'get-dynamic-test-log-url',
+  description: 'Get the log file url for a test log',
+  inputSchema: z.object({
+    logMetadata: logMetadataSchema,
+    logType: z.nativeEnum(LogTypes),
+  }),
+  outputSchema: z.object({
+    logFileUrl: z.string(),
+  }),
+})
+  .then(getTestResultsStep)
+  .then(getFinalTestLogUrl)
+  .commit();
+
+const simpleLogTypes = [
+  LogTypes.EVERGREEN_TASK_FILE,
+  LogTypes.EVERGREEN_TASK_LOGS,
+];
+const getLogFileUrlWorkflow = createWorkflow({
+  id: 'get-log-file-url',
+  description: 'Get the log file url',
+  inputSchema: z.object({
+    logMetadata: logMetadataSchema,
+  }),
+  outputSchema: z.object({
+    logFileUrl: z.string(),
+  }),
+})
+  .then(step1ValidateLogFileUrl)
+  .branch([
+    [
+      async ({ inputData }) => simpleLogTypes.includes(inputData.logType),
+      step2SimpleLogFileUrl,
+    ],
+    [
+      async ({ inputData }) =>
+        inputData.logType === LogTypes.EVERGREEN_TEST_LOGS,
+      getDynamicTestLogUrlWorkflow,
+    ],
+  ])
+  .commit();
+
+export default getLogFileUrlWorkflow;

--- a/src/mastra/workflows/evergreen/getLogFileUrlWorkflow.ts
+++ b/src/mastra/workflows/evergreen/getLogFileUrlWorkflow.ts
@@ -15,13 +15,11 @@ const step1ValidateLogFileUrl = createStep({
     logMetadata: logMetadataSchema,
   }),
   outputSchema: z.object({
-    logType: z.nativeEnum(LogTypes),
     logMetadata: logMetadataSchema,
   }),
   execute: async ({ inputData }) => {
     const { logMetadata } = inputData;
     return {
-      logType: logMetadata.log_type,
       logMetadata: logMetadata,
     };
   },
@@ -32,7 +30,6 @@ const step2SimpleLogFileUrl = createStep({
   description: 'Get the log file url from a template string',
   inputSchema: z.object({
     logMetadata: logMetadataSchema,
-    logType: z.nativeEnum(LogTypes),
   }),
   outputSchema: z.string(),
   execute: async ({ inputData }) => {
@@ -120,7 +117,6 @@ const step2GetDynamicTestLogUrlWorkflow = createWorkflow({
   description: 'Get the log file url for a test log',
   inputSchema: z.object({
     logMetadata: logMetadataSchema,
-    logType: z.nativeEnum(LogTypes),
   }),
   outputSchema: z.string(),
 })
@@ -167,12 +163,13 @@ const getLogFileUrlWorkflow = createWorkflow({
   .then(step1ValidateLogFileUrl)
   .branch([
     [
-      async ({ inputData }) => simpleLogTypes.includes(inputData.logType),
+      async ({ inputData }) =>
+        simpleLogTypes.includes(inputData.logMetadata.log_type),
       step2SimpleLogFileUrl,
     ],
     [
       async ({ inputData }) =>
-        inputData.logType === LogTypes.EVERGREEN_TEST_LOGS,
+        inputData.logMetadata.log_type === LogTypes.EVERGREEN_TEST_LOGS,
       step2GetDynamicTestLogUrlWorkflow,
     ],
   ])

--- a/src/mastra/workflows/evergreen/index.ts
+++ b/src/mastra/workflows/evergreen/index.ts
@@ -1,4 +1,5 @@
+import getLogFileUrlWorkflow from './getLogFileUrlWorkflow';
 import getTaskHistoryWorkflow from './getTaskHistoryWorkflow';
 import getVersionWorkflow from './getVersionWorkflow';
 
-export { getTaskHistoryWorkflow, getVersionWorkflow };
+export { getTaskHistoryWorkflow, getVersionWorkflow, getLogFileUrlWorkflow };


### PR DESCRIPTION
DEVPROD-21581


### Description
I observed that sometimes for test logs we might not always get the correct log file url. This is due to the fact that certain test log urls are simply pointers to the test logs instead of relying on our test log infrastructure. So we can't compute the url we should instead reference the url directly from the test result. This pr adds a new workflow that is designed to compute test logs depending on log type. 
For task logs which are always on evergreens infrastructure we use a static url, 
For task files we will use the evergreen proxy to download the log file so we always use a static url.
For test logs we fetch the test results, and find the correct log url from the test results and use that.

### Testing
Tried on every log file variation and confirmed parsley ai always used the same url as the underlying log file

