### PR TITLE
DEVPROD-21726 Turn log analyzer workflow into a tool

### DIFF
--- a/src/mastra/agents/planning/sageThinkingAgent.ts
+++ b/src/mastra/agents/planning/sageThinkingAgent.ts
@@ -1,9 +1,10 @@
 import { Agent } from '@mastra/core/agent';
+import { RuntimeContext } from '@mastra/core/runtime-context';
 import { Memory } from '@mastra/memory';
+
 import { gpt41 } from '../../models/openAI/gpt41';
 import { memoryStore } from '../../utils/memory';
 import { logCoreAnalyzerTool } from '../../workflows/logCoreAnalyzerWorkflow';
-import { USER_ID } from '../constants';
 import { askEvergreenAgentTool } from '../evergreenAgent';
 import { askQuestionClassifierAgentTool } from './questionClassifierAgent';
 
@@ -22,11 +23,7 @@ export const sageThinkingAgent: Agent = new Agent({
   description:
     'A agent that thinks about the user question and decides the next action.',
   memory: sageThinkingAgentMemory,
-  instructions: ({ runtimeContext }) => {
-    const userID = runtimeContext.get(USER_ID);
-    const logMetadata = runtimeContext.get('logMetadata');
-    const logURL = runtimeContext.get('logURL');
-    return `
+  instructions: ({ runtimeContext }) => `
   You are Parsley AI. A senior software engineer that can think about a users questions and decide on a course of action to answer the question. 
   You have a deep understanding of the evergreen platform and have access to a series of tools that can help you answer any question.
 
@@ -47,15 +44,12 @@ export const sageThinkingAgent: Agent = new Agent({
 
   ## Rules
   When answering a user question using markdown avoid using large headings. Keep it simple and concise.
+  When passing ids to agents, Make sure to always pass the full task id, DO NOT pass a shortened task id or truncate it in any way.
   
   <ADDITIONAL_CONTEXT>
-  User ID: ${userID}
-  Log Metadata: ${JSON.stringify(logMetadata)}
-  The Raw log url for the log we are looking at is: ${logURL}
+  ${stringifyRuntimeContext(runtimeContext)}
   </ADDITIONAL_CONTEXT>
-
-  `;
-  },
+  `,
   model: gpt41,
   tools: {
     askQuestionClassifierAgentTool,
@@ -63,3 +57,8 @@ export const sageThinkingAgent: Agent = new Agent({
     logCoreAnalyzerTool,
   },
 });
+
+const stringifyRuntimeContext = (runtimeContext: RuntimeContext) => {
+  const context = runtimeContext.toJSON();
+  return JSON.stringify(context, null, 2);
+};

--- a/src/mastra/agents/planning/sageThinkingAgent.ts
+++ b/src/mastra/agents/planning/sageThinkingAgent.ts
@@ -1,7 +1,6 @@
 import { Agent } from '@mastra/core/agent';
 import { RuntimeContext } from '@mastra/core/runtime-context';
 import { Memory } from '@mastra/memory';
-
 import { gpt41 } from '../../models/openAI/gpt41';
 import { memoryStore } from '../../utils/memory';
 import { logCoreAnalyzerTool } from '../../workflows/logCoreAnalyzerWorkflow';

--- a/src/mastra/agents/planning/sageThinkingAgent.ts
+++ b/src/mastra/agents/planning/sageThinkingAgent.ts
@@ -2,7 +2,7 @@ import { Agent } from '@mastra/core/agent';
 import { Memory } from '@mastra/memory';
 import { gpt41 } from '../../models/openAI/gpt41';
 import { memoryStore } from '../../utils/memory';
-import { logCoreAnalyzerWorkflow } from '../../workflows/logCoreAnalyzerWorkflow';
+import { logCoreAnalyzerTool } from '../../workflows/logCoreAnalyzerWorkflow';
 import { USER_ID } from '../constants';
 import { askEvergreenAgentTool } from '../evergreenAgent';
 import { askQuestionClassifierAgentTool } from './questionClassifierAgent';
@@ -35,7 +35,7 @@ export const sageThinkingAgent: Agent = new Agent({
   1. **evergreenAgent**: Fetches data from Evergreen APIs (tasks, builds, versions, patches, logs from Evergreen)
      - Use for: Getting task details, build status, version info, patch data, fetching logs from Evergreen
   
-  2. **logCoreAnalyzerWorkflow**: Analyzes raw log/text content that you provide
+  2. **logCoreAnalyzerTool**: Analyzes raw log/text content that you provide
      - Use for: Analyzing log files or text content when you have the actual content
      - Accepts: file path (local), URL (direct link to content), or raw text string
      - Does NOT: Fetch from Evergreen (use evergreenAgent for that first)
@@ -60,8 +60,6 @@ export const sageThinkingAgent: Agent = new Agent({
   tools: {
     askQuestionClassifierAgentTool,
     askEvergreenAgentTool,
-  },
-  workflows: {
-    logCoreAnalyzerWorkflow,
+    logCoreAnalyzerTool,
   },
 });

--- a/src/mastra/workflows/logCoreAnalyzerWorkflow.ts
+++ b/src/mastra/workflows/logCoreAnalyzerWorkflow.ts
@@ -468,8 +468,12 @@ export const logCoreAnalyzerTool: ReturnType<typeof createTool> = createTool({
       return runResult.result;
     }
     if (runResult.status === 'failed') {
-      throw new Error(runResult.error.message);
+      throw new Error(
+        `Log analyzer workflow failed: ${runResult.error.message}`
+      );
     }
-    throw new Error(`Unsupported tool status error ${runResult.status}`);
+    throw new Error(
+      `Unexpected workflow execution status: ${runResult.status}. Expected 'success' or 'failed'.`
+    );
   },
 });

--- a/src/mastra/workflows/logCoreAnalyzerWorkflow.ts
+++ b/src/mastra/workflows/logCoreAnalyzerWorkflow.ts
@@ -453,7 +453,9 @@ export const logCoreAnalyzerWorkflow = createWorkflow({
 
 export const logCoreAnalyzerTool: ReturnType<typeof createTool> = createTool({
   id: 'logCoreAnalyzerTool',
-  description: 'Analyzes log files and text content',
+  description:
+    logCoreAnalyzerWorkflow.description ||
+    'Analyzes log files and text content',
   inputSchema: logCoreAnalyzerWorkflow.inputSchema,
   outputSchema: logCoreAnalyzerWorkflow.outputSchema,
   execute: async ({ context, runtimeContext, tracingContext }) => {


### PR DESCRIPTION
DEVPROD-21726


### Description
When using Sage, I observed that its response generation slows down after invoking the log analyzer. Upon investigation, I discovered that the entire tool step was being carried through in the request stream. This included the downloaded file, the chunked log, and all intermittent analysis steps.

As a result:
The LLM was forced to keep the entire log file in context for every completion.
The full task analysis process was returned to the client. For example, analyzing a 30 MB log meant sending the entire file back to the user.

This PR changes the workflow by embedding it directly within a tool. The workflow now executes inside the tool, and none of its intermediate steps are exposed or propagated back to the client. In turn, the tool behaves as a simple input–output mechanism, with no reasoning steps included in the response.

### Testing
Tested and saw much better performance

