### PR TITLE
DEVPROD-21748: Add deploy promotion step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -25,8 +25,7 @@ steps:
         from_secret: ecr_secret_key
     when:
       event:
-        - pull_request
-        - push
+        - promote
 
   - name: deploy-staging
     image: public.ecr.aws/kanopy/drone-helm:v3

--- a/.drone.yml
+++ b/.drone.yml
@@ -26,6 +26,7 @@ steps:
     when:
       event:
         - promote
+        - push
 
   - name: deploy-staging
     image: public.ecr.aws/kanopy/drone-helm:v3

--- a/.drone.yml
+++ b/.drone.yml
@@ -63,6 +63,8 @@ steps:
         from_secret: prod_kubernetes_token
       wait_for_upgrade: true
     when:
+      branch:
+        - main
       event:
         - promote
       target:

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,28 @@ steps:
         from_secret: ecr_secret_key
     when:
       event:
+        - pull-request
         - push
+
+  - name: deploy-staging
+    image: public.ecr.aws/kanopy/drone-helm:v3
+    settings:
+      chart: mongodb/web-app
+      chart_version: 4.31.0
+      add_repos: [mongodb=https://10gen.github.io/helm-charts]
+      namespace: devprod-evergreen
+      release: sage
+      values: image.tag=git-${DRONE_COMMIT_SHA:0:7},image.repository=795250896452.dkr.ecr.us-east-1.amazonaws.com/devprod-evergreen/${DRONE_REPO_NAME},ingress.enabled=true,ingress.hosts[0]=sage.devprod-evergreen.staging.corp.mongodb.com
+      values_files: [ "environments/staging.yaml" ]
+      api_server: https://api.staging.corp.mongodb.com
+      kubernetes_token:
+        from_secret: staging_kubernetes_token
+      wait_for_upgrade: true
+    when:
+      event:
+        - promote
+      target:
+        - staging
 
   - name: deploy-prod
     image: public.ecr.aws/kanopy/drone-helm:v3
@@ -40,6 +61,9 @@ steps:
       api_server: https://api.prod.corp.mongodb.com
       kubernetes_token:
         from_secret: prod_kubernetes_token
+      wait_for_upgrade: true
     when:
       event:
-        - push
+        - promote
+      target:
+        - production

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,7 @@ steps:
         from_secret: ecr_secret_key
     when:
       event:
-        - pull-request
+        - pull_request
         - push
 
   - name: deploy-staging

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ A TypeScript-based Express.js server powering the Evergreen AI Service.
 
 ### Prerequisites
 
-* Node.js v22 or higher
-* Yarn package manager
-* MongoDB instance installed and running
-* Azure OpenAI key
+- Node.js v22 or higher
+- Yarn package manager
+- MongoDB instance installed and running
+- Azure OpenAI key
 
 ### Environment Variables
 
@@ -129,9 +129,9 @@ Launches a local Mastra server at `http://localhost:4111` for agent testing.
 
 ### Customizing Agents
 
-* **Agents**: Add or update agents in `src/mastra/agents`.
-* **Tools**: Place reusable tools in `src/mastra/tools`. Tools are composable functions an agent can call.
-* **Workflows**: Add workflows to `src/mastra/workflows`. Workflows define multi-step logic that agents can follow.
+- **Agents**: Add or update agents in `src/mastra/agents`.
+- **Tools**: Place reusable tools in `src/mastra/tools`. Tools are composable functions an agent can call.
+- **Workflows**: Add workflows to `src/mastra/workflows`. Workflows define multi-step logic that agents can follow.
 
 All agents and workflows should be registered in `src/mastra/index.ts`.
 
@@ -184,14 +184,26 @@ types up to date. The command will also run Prettier on the generated file.
 ### Troubleshooting
 
 • If ESLint or codegen cannot find the schema, verify the `sdlschema` symlink
-  path and that the Evergreen repository is on the expected branch.  
+path and that the Evergreen repository is on the expected branch.
+
 - If ESLint or codegen cannot find the schema, verify the `sdlschema` symlink
-  path and that the Evergreen repository is on the expected branch.  
+  path and that the Evergreen repository is on the expected branch.
 - If dependencies appear out of date, try `yarn install` or `yarn clean` followed
   by `yarn install` to refresh `node_modules`.
-  
-## Deployment
 
-### Staging Deploys
+## Deploys
 
-To deploy your changes to Sage's staging environment, make changes on a new branch. Update the .drone.yml's `trigger` field to include your branch name, commit, and push up to GitHub. A Drone build will be kicked off automatically.
+### Staging
+
+Before pushing to staging, drop a note in 🔒evergreen-ai-devs to make sure no one is using it.
+
+#### Drone
+
+Drone can [promote](https://docs.drone.io/promote/) builds opened on PRs to staging. Before starting, [install and configure the Drone CLI](https://kanopy.corp.mongodb.com/docs/cicd/advanced_drone/#drone-cli).
+
+1. Open a PR with your changes (a draft is okay). This will kick off the `publish` step.
+2. Once completed, run `drone build evergreen-ci/sage <PR_NUMBER> staging`.
+
+#### Local
+
+Local deploys are slower but useful. First install [Rancher Desktop](https://rancherdesktop.io) as your container manager. Open Rancher and then run `yarn deploy:staging` from Sage to kick off the deploy.

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Drone can [promote](https://docs.drone.io/promote/) builds opened on PRs to stag
 1. Open a PR with your changes (a draft is okay). This will kick off the `publish` step.
 2. Once completed, either:
 
-- Run `drone build evergreen-ci/sage <DRONE_BUILD_NUMBER> staging` from your machine
+- Run `drone build promote evergreen-ci/sage <DRONE_BUILD_NUMBER> staging` from your machine
 - Click the ellipsis button > Promote on your build's page on Drone
 
 #### Local

--- a/README.md
+++ b/README.md
@@ -203,11 +203,15 @@ Drone can [promote](https://docs.drone.io/promote/) builds opened on PRs to stag
 
 1. Open a PR with your changes (a draft is okay). This will kick off the `publish` step.
 2. Once completed, either:
-  - Run `drone build promote evergreen-ci/sage <DRONE_BUILD_NUMBER> staging` from your machine
-  - Click the ellipsis button > Promote on your build's page on Drone. Enter "staging" in the "Target" field.
+    - Run `drone build promote evergreen-ci/sage <DRONE_BUILD_NUMBER> staging` from your machine.
+    - Click `…` > `Promote` on your build's page on Drone. Enter "staging" in the "Target" field and submit.
 
 #### Local
 
 Local deploys are slower but useful. First install [Rancher Desktop](https://rancherdesktop.io) as your container manager. Open Rancher and then run `yarn deploy:staging` from Sage to kick off the deploy.
 
 Note that Drone's [deployments page](https://drone.corp.mongodb.com/evergreen-ci/sage/deployments) will not reflect local deploys.
+
+### Production
+
+To deploy to production, follow the Drone steps above, using `production` as the target instead of `staging`. Note that you must be promoting a Drone build that pushed a commit to `main`.

--- a/README.md
+++ b/README.md
@@ -203,9 +203,8 @@ Drone can [promote](https://docs.drone.io/promote/) builds opened on PRs to stag
 
 1. Open a PR with your changes (a draft is okay). This will kick off the `publish` step.
 2. Once completed, either:
-
-- Run `drone build promote evergreen-ci/sage <DRONE_BUILD_NUMBER> staging` from your machine
-- Click the ellipsis button > Promote on your build's page on Drone
+  - Run `drone build promote evergreen-ci/sage <DRONE_BUILD_NUMBER> staging` from your machine
+  - Click the ellipsis button > Promote on your build's page on Drone. Enter "staging" in the "Target" field.
 
 #### Local
 

--- a/README.md
+++ b/README.md
@@ -202,8 +202,13 @@ Before pushing to staging, drop a note in 🔒evergreen-ai-devs to make sure no 
 Drone can [promote](https://docs.drone.io/promote/) builds opened on PRs to staging. Before starting, [install and configure the Drone CLI](https://kanopy.corp.mongodb.com/docs/cicd/advanced_drone/#drone-cli).
 
 1. Open a PR with your changes (a draft is okay). This will kick off the `publish` step.
-2. Once completed, run `drone build evergreen-ci/sage <PR_NUMBER> staging`.
+2. Once completed, either:
+
+- Run `drone build evergreen-ci/sage <DRONE_BUILD_NUMBER> staging` from your machine
+- Click the ellipsis button > Promote on your build's page on Drone
 
 #### Local
 
 Local deploys are slower but useful. First install [Rancher Desktop](https://rancherdesktop.io) as your container manager. Open Rancher and then run `yarn deploy:staging` from Sage to kick off the deploy.
+
+Note that Drone's [deployments page](https://drone.corp.mongodb.com/evergreen-ci/sage/deployments) will not reflect local deploys.

--- a/README.md
+++ b/README.md
@@ -183,9 +183,6 @@ types up to date. The command will also run Prettier on the generated file.
 
 ### Troubleshooting
 
-• If ESLint or codegen cannot find the schema, verify the `sdlschema` symlink
-path and that the Evergreen repository is on the expected branch.
-
 - If ESLint or codegen cannot find the schema, verify the `sdlschema` symlink
   path and that the Evergreen repository is on the expected branch.
 - If dependencies appear out of date, try `yarn install` or `yarn clean` followed

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Drone can [promote](https://docs.drone.io/promote/) builds opened on PRs to stag
 
 Local deploys are slower but useful. First install [Rancher Desktop](https://rancherdesktop.io) as your container manager. Open Rancher and then run `yarn deploy:staging` from Sage to kick off the deploy.
 
-Note that Drone's [deployments page](https://drone.corp.mongodb.com/evergreen-ci/sage/deployments) will not reflect local deploys.
+Note that Drone's [deployments page](https://drone.corp.mongodb.com/evergreen-ci/sage/deployments) will not reflect local deploys. To verify your deploy has been pushed, install [Helm](https://kanopy.corp.mongodb.com/docs/configuration/helm/) and run `helm status sage`.
 
 ### Production
 


### PR DESCRIPTION
DEVPROD-21748


### Description
<!-- add description, context, thought process, etc -->

Allow promoting builds to staging and production environments.

### Testing
<!-- add a description of how you tested it -->
View promoted build [here](https://drone.corp.mongodb.com/evergreen-ci/sage/629). Drone's [deployments tab](https://drone.corp.mongodb.com/evergreen-ci/sage/deployments) is also populated.