### PR TITLE
DEVPROD-21433: Refactor eval suite and add tests for QuestionClassifierAgent

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -20,7 +20,6 @@ post:
   - func: assume-ec2-role
   - func: attach-mongod-logs
   - func: attach-test-results
-  - func: attach-braintrust-results
 
 buildvariants:
   - name: ubuntu2204-small
@@ -40,7 +39,13 @@ buildvariants:
       - name: lint
       - name: test
       - name: e2e
-      - name: eval
+      - name: evergreen-evals
+      - name: question-classifier-evals
+    display_tasks:
+      - name: evals
+        execution_tasks:
+          - "evergreen-evals"
+          - "question-classifier-evals"
 
 tasks:
   - name: compile
@@ -62,7 +67,7 @@ tasks:
       - func: yarn-build
       - func: wait-for-evergreen
       - func: yarn-e2e
-  - name: eval
+  - name: evergreen-evals
     commands:
       - func: setup-mongodb
       - func: run-make-background
@@ -70,8 +75,19 @@ tasks:
           target: local-evergreen
       - func: wait-for-evergreen
       - func: yarn-eval
-
-
+        vars:
+          eval_dir: evergreenAgent
+      - func: attach-braintrust-results
+        vars:
+          xml_file_name: evergreen_evals.xml
+  - name: question-classifier-evals
+    commands:
+      - func: yarn-eval
+        vars:
+          eval_dir: questionClassifierAgent
+      - func: attach-braintrust-results
+        vars:
+          xml_file_name: question_classifier_evals.xml
 
 functions:
   attach-test-results:
@@ -84,7 +100,7 @@ functions:
     command: attach.xunit_results
     params:
       files:
-        - "./sage/bin/braintrust_evals.xml"
+        - ./sage/bin/${xml_file_name}
 
   attach-mongod-logs:
     command: s3.put
@@ -294,7 +310,8 @@ functions:
         AZURE_OPENAI_API_KEY: ${AZURE_OPENAI_API_KEY}
         AZURE_OPENAI_ENDPOINT: ${AZURE_OPENAI_ENDPOINT}
         BRAINTRUST_API_KEY: ${BRAINTRUST_API_KEY}
+        EVAL_DIR: ${eval_dir}
       shell: bash
       script: |
         ${PREPARE_SHELL}
-        yarn eval:send_to_braintrust
+        .evergreen/scripts/publish-evals.sh

--- a/.evergreen/scripts/publish-evals.sh
+++ b/.evergreen/scripts/publish-evals.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Braintrust CLI does not correctly fail if there are compile errors while running evals, so this is handled by the script below.
+
+if [ -d "bin" ]; then
+    echo "Directory /bin already exists."
+else
+    mkdir bin
+fi
+
+# Pipe stderr output to stdout, then check for string that indicates failure. 
+if yarn eval:send_to_braintrust src/evals/$EVAL_DIR 2>&1 | tee bin/$EVAL_DIR.log  | grep -q "Failed to compile"; then
+    echo "ERROR: The eval tests could not run due to a compile failure."
+    exit 1
+fi
+
+# Print out the log content in the task.
+cat bin/$EVAL_DIR.log

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -3,5 +3,5 @@ module.exports = {
   '*.{ts,tsx,js,jsx}': ['yarn eslint:strict'],
 
   // Run Prettier formatting check on all supported files
-  '*.{ts,tsx,js,jsx,json,md}': ['yarn format:check'],
+  '*.{ts,tsx,js,jsx,json}': ['yarn format:check'],
 };

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -3,5 +3,5 @@ module.exports = {
   '*.{ts,tsx,js,jsx}': ['yarn eslint:strict'],
 
   // Run Prettier formatting check on all supported files
-  '*.{ts,tsx,js,jsx,json}': ['yarn format:check'],
+  '*.{ts,tsx,js,jsx,json,md}': ['yarn format:check'],
 };

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "mastra:start": "node --import=./.mastra/output/instrumentation.mjs .mastra/output/index.mjs",
     "mastra:full": "yarn mastra:build && yarn mastra:start",
     "prepare": "husky",
-    "eval": "ENABLE_SENTRY_PROFILING=false npx braintrust eval --no-send-logs src/evals/",
-    "eval:send_to_braintrust": "ENABLE_SENTRY_PROFILING=false npx braintrust eval src/evals/"
+    "eval": "ENABLE_SENTRY_PROFILING=false npx braintrust eval --no-send-logs",
+    "eval:send_to_braintrust": "ENABLE_SENTRY_PROFILING=false npx braintrust eval"
   },
   "dependencies": {
     "@ai-sdk/azure": "^2.0.24",

--- a/src/evals/README.md
+++ b/src/evals/README.md
@@ -1,0 +1,30 @@
+# About Evals
+
+
+Evals are a way to test the quality of an AI agent's responses.
+
+
+## How to Run Evals
+
+
+To run the eval tests, do `yarn eval src/evals/<eval_folder_name>` from the root Sage directory. Note that this will only run the tests locally on your computer as it uses the `--no-send-logs` flag, which prevents forwarding any results to Braintrust.
+
+
+Additional requirements:
+* Make sure your Azure and Braintrust API keys are correctly populated in your `.env` files.
+* If you're running an agent that needs to query the Evergreen GraphQL server, then you must run Evergreen in another terminal (via `make evergreen-local`).
+
+
+## Scoring
+
+
+Agent responses are evaluated using scorers. There are many scorers already available to you via Braintrust's `autoevals` package. You can choose from any of the existing scorers [here](https://github.com/braintrustdata/autoevals/blob/main/js/manifest.ts).
+
+
+Additionally, you can write custom scorers. For example, `ToolUsage` is a custom scorer that checks that our agents are calling the correct tools. Refer to [official documentation](https://www.braintrust.dev/docs/guides/experiments/write#define-your-own-scorers) to learn more about custom scorers.
+
+
+## Reporting
+
+
+Braintrust also allows you to customize how you report results. We define our own reporting functions since we have additional requirements to surface the results in Evergreen CI. Refer to [official documentation](https://www.braintrust.dev/docs/guides/experiments/write#custom-reporters) to learn more about customizing reporting functions.

--- a/src/evals/constants.ts
+++ b/src/evals/constants.ts
@@ -1,0 +1,18 @@
+const PROJECT_NAME = 'sage-prod';
+
+/**
+ * These are the users declared in the local Evergreen database.
+ */
+enum TestUser {
+  Regular = 'regular',
+  Privileged = 'privileged',
+  Admin = 'admin',
+}
+
+enum ReporterName {
+  Evergreen = 'Evergreen Eval Reporter',
+  QuestionClassifier = 'Question Classifier Eval Reporter',
+  SageThinking = 'Sage Thinking Eval Reporter',
+}
+
+export { PROJECT_NAME, TestUser, ReporterName };

--- a/src/evals/evergreenAgent/agent.eval.ts
+++ b/src/evals/evergreenAgent/agent.eval.ts
@@ -1,0 +1,64 @@
+import { RuntimeContext } from '@mastra/core/runtime-context';
+import { ToolResultPart } from 'ai';
+import { Factuality } from 'autoevals';
+import { Eval } from 'braintrust';
+import { ReporterName, PROJECT_NAME } from 'evals/constants';
+import { toolUsage } from 'evals/scorers';
+import { callModelWithTrace } from 'evals/tracer';
+import { ModelOutput } from 'evals/types';
+import { mastra } from 'mastra';
+import { USER_ID, EVERGREEN_AGENT_NAME } from 'mastra/agents/constants';
+import { testCases } from './testCases';
+import { TestInput, TestResult } from './types';
+
+const callEvergreenAgent = async (
+  input: TestInput
+): ModelOutput<TestInput, TestResult> => {
+  const runtimeContext = new RuntimeContext();
+  runtimeContext.set(USER_ID, input.user);
+  const agent = mastra.getAgent(EVERGREEN_AGENT_NAME);
+  const response = await agent.generateVNext(input.content, {
+    runtimeContext,
+    format: 'aisdk',
+  });
+  const toolResults = response.toolResults as ToolResultPart[];
+  const toolsUsed = toolResults.map(t => t.toolName);
+  const output = {
+    text: response.text,
+    toolsUsed,
+  };
+  return {
+    ...response,
+    input,
+    output,
+  };
+};
+
+Eval(
+  PROJECT_NAME,
+  {
+    data: testCases,
+    task: async (input: TestInput) =>
+      await callModelWithTrace<TestInput, TestResult>(() =>
+        callEvergreenAgent(input)
+      ),
+    scores: [
+      ({ expected, input, output }) =>
+        Factuality.partial({})({
+          expected: expected.text,
+          output: output.text,
+          input: input.content,
+        }),
+      ({ expected, output }) =>
+        toolUsage({
+          output: output.toolsUsed,
+          expected: expected.toolsUsed,
+        }),
+    ],
+    experimentName: 'Evergreen Agent Eval',
+    description: 'Tests for the Evergreen agent.',
+  },
+  {
+    reporter: ReporterName.Evergreen,
+  }
+);

--- a/src/evals/evergreenAgent/reporter.eval.ts
+++ b/src/evals/evergreenAgent/reporter.eval.ts
@@ -1,0 +1,51 @@
+import { ReporterName } from 'evals/constants';
+import { getReporter } from 'evals/reporter.eval';
+import { TestInput, TestResult, TestMetadata, Scores } from './types';
+
+const calculateScores = (scores: Scores, scoreThresholds: Scores) => {
+  const factualityScore = scores.Factuality;
+  const toolUsageScore = scores.ToolUsage;
+
+  const factualityPassCutoff = scoreThresholds.Factuality;
+  const toolUsagePassCutoff = scoreThresholds.ToolUsage;
+
+  const messages: string[] = [];
+  if (factualityScore < factualityPassCutoff) {
+    messages.push(
+      `Factuality score ${factualityScore} is below threshold ${factualityPassCutoff}.`
+    );
+  }
+  if (toolUsageScore < toolUsagePassCutoff) {
+    messages.push(
+      `Tool Usage score ${toolUsageScore} is below threshold ${toolUsagePassCutoff}.`
+    );
+  }
+  return messages;
+};
+
+const printResults = (
+  scores: Scores,
+  scoreThresholds: Scores,
+  testName: string
+) => {
+  const resultsTable = {
+    Factuality: {
+      actual: scores.Factuality,
+      expected: `>= ${scoreThresholds.Factuality}`,
+    },
+    'Tool Usage': {
+      actual: scores.ToolUsage,
+      expected: `>= ${scoreThresholds.ToolUsage}`,
+    },
+  };
+  console.log(testName);
+  console.table(resultsTable);
+};
+
+getReporter<TestInput, TestResult, TestMetadata, Scores>({
+  calculateScores,
+  printResults,
+  reporterName: ReporterName.Evergreen,
+  testSuiteName: 'Evergreen Evals',
+  xmlFileOutputName: 'evergreen_evals',
+});

--- a/src/evals/evergreenAgent/testCases.ts
+++ b/src/evals/evergreenAgent/testCases.ts
@@ -1,0 +1,143 @@
+import { TestUser } from 'evals/constants';
+import { TestCase } from './types';
+
+const restrictedTaskId =
+  'evg_lint_generate_lint_ecbbf17f49224235d43416ea55566f3b1894bbf7_25_03_21_21_09_20';
+
+const testUnauthorized: TestCase = {
+  input: {
+    content: `What is the status of this task: ${restrictedTaskId}?`,
+    user: TestUser.Regular,
+  },
+  expected: {
+    text: `Unable to retrieve the status of this task due to insufficient permissions.`,
+    toolsUsed: ['getTaskTool'],
+  },
+  metadata: {
+    testName: 'Regular user cannot access restricted task',
+    description: 'Tests that a regular user cannot access a restricted task.',
+    scoreThresholds: {
+      Factuality: 0.5,
+      ToolUsage: 1.0,
+    },
+  },
+};
+
+const unrestrictedTaskId =
+  'evergreen_ubuntu1604_test_service_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48';
+
+const testGetTaskTool: TestCase = {
+  input: {
+    content: `What is the status of this task: ${unrestrictedTaskId}?`,
+    user: TestUser.Regular,
+  },
+  expected: {
+    text: `The status of the task "${unrestrictedTaskId}" is "failed".`,
+    toolsUsed: ['getTaskTool'],
+  },
+  metadata: {
+    testName: 'Test retrieving task',
+    description:
+      'Tests that a user can successfully fetch a task from Evergreen.',
+    scoreThresholds: {
+      Factuality: 0.7,
+      ToolUsage: 1.0,
+    },
+  },
+};
+
+const taskFileId =
+  'spruce_ubuntu1604_test_2c9056df66d42fb1908d52eed096750a91f1f089_22_03_02_16_45_12';
+
+const testGetTaskFilesTool: TestCase = {
+  input: {
+    content: `Tell me how many files are associated with task: ${taskFileId}. What are the names of the files?`,
+    user: TestUser.Regular,
+  },
+  expected: {
+    text: `The task ${taskFileId} has a 1 associated file. It is named "sample file".`,
+    toolsUsed: ['getTaskFilesTool'],
+  },
+  metadata: {
+    testName: 'Test retrieving task files',
+    description: 'Tests that agent can retrieve and describe task files.',
+    scoreThresholds: {
+      Factuality: 0.7,
+      ToolUsage: 1.0,
+    },
+  },
+};
+
+const taskTestId =
+  'spruce_ubuntu1604_check_codegen_d54e2c6ede60e004c48d3c4d996c59579c7bbd1f_22_03_02_15_41_35';
+
+const testGetTaskTestsTool: TestCase = {
+  input: {
+    content: `Tell me how many failing tests are associated with task: ${taskTestId}.`,
+    user: TestUser.Regular,
+  },
+  expected: {
+    text: `The task ${taskTestId} has 1 failing test.`,
+    toolsUsed: ['getTaskTestsTool'],
+  },
+  metadata: {
+    testName: 'Test retrieving task tests',
+    description: 'Tests that agent can retrieve and describe task tests.',
+    scoreThresholds: {
+      Factuality: 0.7,
+      ToolUsage: 1.0,
+    },
+  },
+};
+
+const testGetVersionWorkflow: TestCase = {
+  input: {
+    content: `What is the status of the version associated with task: ${unrestrictedTaskId}.`,
+    user: TestUser.Regular,
+  },
+  expected: {
+    text: `The status of the version associated with task ${unrestrictedTaskId} is "failed".`,
+    toolsUsed: ['getVersionWorkflow'],
+  },
+  metadata: {
+    testName: 'Test version workflow',
+    description:
+      'Tests that agent can retrieve associated version information.',
+    scoreThresholds: {
+      Factuality: 0.7,
+      ToolUsage: 1.0,
+    },
+  },
+};
+
+const historyTaskId =
+  'spruce_ubuntu1604_check_codegen_d54e2c6ede60e004c48d3c4d996c59579c7bbd1f_22_03_02_15_41_35';
+
+const testGetTaskHistoryWorkflow: TestCase = {
+  input: {
+    content: `The task with ID ${historyTaskId} failed. Is this the first time that this task has failed in this project? If it isn't, can you tell me the task ID of when it last failed?`,
+    user: TestUser.Regular,
+  },
+  expected: {
+    text: `No, it is not the first time this task failed. The last time it failed was the task with ID "spruce_ubuntu1604_check_codegen_74af23f72da201d5bd7b651161ab8e496bf44ec7_22_02_25_14_21_37".`,
+    toolsUsed: ['getTaskHistoryWorkflow'],
+  },
+  metadata: {
+    testName: 'Test task history workflow',
+    description:
+      'Tests that agent can retrieve associated history information.',
+    scoreThresholds: {
+      Factuality: 0.4,
+      ToolUsage: 1.0,
+    },
+  },
+};
+
+export const testCases: TestCase[] = [
+  testUnauthorized,
+  testGetTaskTool,
+  testGetTaskFilesTool,
+  testGetTaskTestsTool,
+  testGetVersionWorkflow,
+  testGetTaskHistoryWorkflow,
+];

--- a/src/evals/evergreenAgent/types.ts
+++ b/src/evals/evergreenAgent/types.ts
@@ -1,0 +1,28 @@
+import { TestUser } from 'evals/constants';
+
+export type TestInput = {
+  content: string;
+  user: TestUser;
+};
+
+export type Scores = {
+  Factuality: number;
+  ToolUsage: number;
+};
+
+export type TestMetadata = {
+  description: string;
+  testName: string;
+  scoreThresholds: Scores;
+};
+
+export type TestResult = {
+  text: string;
+  toolsUsed: string[];
+};
+
+export type TestCase = {
+  input: TestInput;
+  expected: TestResult;
+  metadata: TestMetadata;
+};

--- a/src/evals/questionClassifierAgent/agent.eval.ts
+++ b/src/evals/questionClassifierAgent/agent.eval.ts
@@ -1,0 +1,55 @@
+import { ExactMatch } from 'autoevals';
+import { Eval } from 'braintrust';
+import { ReporterName, PROJECT_NAME } from 'evals/constants';
+import { callModelWithTrace } from 'evals/tracer';
+import { ModelOutput } from 'evals/types';
+import { mastra } from 'mastra';
+import { QUESTION_CLASSIFIER_AGENT_NAME } from 'mastra/agents/constants';
+import { testCases } from './testCases';
+import { TestInput, TestResult } from './types';
+
+const callQuestionClassifierAgent = async (
+  input: TestInput
+): ModelOutput<TestInput, TestResult> => {
+  const agent = mastra.getAgent(QUESTION_CLASSIFIER_AGENT_NAME);
+  const response = await agent.generateVNext(input, { format: 'aisdk' });
+  const responseJSON = JSON.parse(response.text);
+  const output = {
+    questionClass: responseJSON.questionClass,
+    nextAction: responseJSON.nextAction,
+  };
+  return {
+    ...response,
+    input,
+    output,
+  };
+};
+
+Eval(
+  PROJECT_NAME,
+  {
+    data: testCases,
+    task: async (input: TestInput) =>
+      await callModelWithTrace<TestInput, TestResult>(() =>
+        callQuestionClassifierAgent(input)
+      ),
+    scores: [
+      ({ expected, output }) =>
+        ExactMatch.partial({})({
+          expected: {
+            questionClass: expected.questionClass,
+            nextAction: expected.nextAction,
+          },
+          output: {
+            questionClass: output.questionClass,
+            nextAction: output.nextAction,
+          },
+        }),
+    ],
+    experimentName: 'Question Classifier Agent Eval',
+    description: 'Tests for the Question Classifier agent.',
+  },
+  {
+    reporter: ReporterName.QuestionClassifier,
+  }
+);

--- a/src/evals/questionClassifierAgent/reporter.eval.ts
+++ b/src/evals/questionClassifierAgent/reporter.eval.ts
@@ -1,0 +1,38 @@
+import { ReporterName } from 'evals/constants';
+import { getReporter } from 'evals/reporter.eval';
+import { TestInput, TestResult, TestMetadata, Scores } from './types';
+
+const calculateScores = (scores: Scores, scoreThresholds: Scores) => {
+  const exactMatchScore = scores.ExactMatch;
+  const exactMatchCutoff = scoreThresholds.ExactMatch;
+  const messages: string[] = [];
+  if (exactMatchScore < exactMatchCutoff) {
+    messages.push(
+      `Exact Match score ${exactMatchScore} is below threshold ${exactMatchCutoff}.`
+    );
+  }
+  return messages;
+};
+
+const printResults = (
+  scores: Scores,
+  scoreThresholds: Scores,
+  testName: string
+) => {
+  const resultsTable = {
+    'Exact Match': {
+      actual: scores.ExactMatch,
+      expected: scoreThresholds.ExactMatch,
+    },
+  };
+  console.log(testName);
+  console.table(resultsTable);
+};
+
+getReporter<TestInput, TestResult, TestMetadata, Scores>({
+  calculateScores,
+  printResults,
+  reporterName: ReporterName.QuestionClassifier,
+  testSuiteName: 'Question Classifier Evals',
+  xmlFileOutputName: 'question_classifier_evals',
+});

--- a/src/evals/questionClassifierAgent/testCases.ts
+++ b/src/evals/questionClassifierAgent/testCases.ts
@@ -1,0 +1,88 @@
+import { TestCase } from './types';
+
+const testIrrelevantQuestion: TestCase = {
+  input: 'What should I eat for dinner today?',
+  expected: {
+    questionClass: 'IRRELEVANT',
+    nextAction: 'DO_NOT_ANSWER',
+  },
+  metadata: {
+    testName: 'Ignore irrelevant questions',
+    description: 'Tests that irrelevant questions are ignored.',
+    scoreThresholds: {
+      ExactMatch: 1.0,
+    },
+  },
+};
+
+const testEvergreenQuestion: TestCase = {
+  input:
+    "What's the status of this task: evergreen_ubuntu1604_test_service_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48?",
+  expected: {
+    questionClass: 'EVERGREEN',
+    nextAction: 'USE_EVERGREEN_AGENT',
+  },
+  metadata: {
+    testName: 'Identify Evergreen questions',
+    description: 'Tests that agent can identify Evergreen questions.',
+    scoreThresholds: {
+      ExactMatch: 1.0,
+    },
+  },
+};
+
+const testLogQuestion: TestCase = {
+  input:
+    'I want to know more about the cause of failure in this log file: sample_log.txt?',
+  expected: {
+    questionClass: 'LOG',
+    nextAction: 'USE_LOG_ANALYSIS_AGENT',
+  },
+  metadata: {
+    testName: 'Identify log analysis questions',
+    description: 'Tests that agent can identify log analysis questions.',
+    scoreThresholds: {
+      ExactMatch: 1.0,
+    },
+  },
+};
+
+const testSelfAnswerableQuestion: TestCase = {
+  input: 'What does it mean for a task to be blocked?',
+  expected: {
+    questionClass: 'CAN_ANSWER_ON_OWN',
+    nextAction: 'GENERATE_ANSWER_ON_OWN',
+  },
+  metadata: {
+    testName: 'Identify self-answerable questions',
+    description: 'Tests that agent knows when it can answer by itself.',
+    scoreThresholds: {
+      ExactMatch: 1.0,
+    },
+  },
+};
+
+const testCombinationQuestion: TestCase = {
+  input:
+    'For this test log, is it the first time the task has failed this way?',
+  expected: {
+    questionClass: 'COMBINATION',
+    nextAction: 'USE_COMBINATION_ANALYSIS',
+  },
+  metadata: {
+    testName: 'Identify combination questions',
+    description:
+      'Tests that agent can identify combination analysis questions.',
+    scoreThresholds: {
+      ExactMatch: 1.0,
+    },
+  },
+};
+
+export const testCases: TestCase[] = [
+  testIrrelevantQuestion,
+  testEvergreenQuestion,
+  testLogQuestion,
+  testSelfAnswerableQuestion,
+  testCombinationQuestion,
+];

--- a/src/evals/questionClassifierAgent/types.ts
+++ b/src/evals/questionClassifierAgent/types.ts
@@ -1,0 +1,22 @@
+export type TestInput = string;
+
+export type TestResult = {
+  questionClass: string;
+  nextAction: string;
+};
+
+export type Scores = {
+  ExactMatch: number;
+};
+
+export type TestMetadata = {
+  description: string;
+  testName: string;
+  scoreThresholds: Scores;
+};
+
+export type TestCase = {
+  input: TestInput;
+  expected: TestResult;
+  metadata: TestMetadata;
+};

--- a/src/evals/reporter.eval.ts
+++ b/src/evals/reporter.eval.ts
@@ -1,98 +1,82 @@
 import { Reporter, reportFailures } from 'braintrust';
 import junit from 'junit-report-builder';
 import path from 'path';
-import { CustomEvalResult, Thresholds } from './types';
+import { ReporterEvalResult } from './types';
 
-const xmlBuilder = junit.newBuilder();
-const suite = xmlBuilder.testSuite().name('Braintrust Evals');
+export const getReporter = <Input, Output, Metadata, Scores>({
+  calculateScores,
+  printResults,
+  reporterName,
+  testSuiteName,
+  xmlFileOutputName,
+}: {
+  calculateScores: (scores: Scores, scoreThresholds: Scores) => string[];
+  printResults: (
+    scores: Scores,
+    scoreThresholds: Scores,
+    testName: string
+  ) => void;
+  reporterName: string;
+  testSuiteName: string;
+  xmlFileOutputName: string;
+}) => {
+  const xmlBuilder = junit.newBuilder();
+  const testSuite = xmlBuilder.testSuite().name(testSuiteName);
 
-// https://www.braintrust.dev/docs/guides/experiments/write#custom-reporters
-// This is a custom reporter that controls how results are reported in CI.
-// Braintrust will automatically detect and use this reporter.
-Reporter('Evergreen CI reporter', {
-  reportEval: async (evaluator, result, { jsonl, verbose }) => {
-    const { results } = result;
+  const reporter = Reporter(reporterName, {
+    reportEval: async (evaluator, result, { jsonl, verbose }) => {
+      const { results } = result;
 
-    results.forEach(uncasted => {
-      const r = uncasted as CustomEvalResult;
+      // Check that minimum score thresholds have been met.
+      results.forEach(uncasted => {
+        const r = uncasted as ReporterEvalResult<
+          Input,
+          Output,
+          Metadata,
+          Scores
+        >;
 
-      const testCase = suite
-        .testCase()
-        .className(evaluator.evalName)
-        .name(r.metadata.testName);
-      testCase.time(r.output.duration / 1000);
+        const testCase = testSuite
+          .testCase()
+          .className(testSuiteName)
+          .name(r.metadata.testName);
 
-      const factualityScore = r.scores.Factuality ?? 0;
-      const toolUsageScore = r.scores?.['Tool Usage'] ?? 0;
+        testCase.time(r.output.duration / 1000);
 
-      const factualityPassCutoff = r.metadata.thresholds.factuality;
-      const toolUsagePassCutoff = r.metadata.thresholds.toolUsage;
-
-      const failedFactuality = factualityScore < factualityPassCutoff;
-      const failedToolUsage = toolUsageScore < toolUsagePassCutoff;
-
-      if (r.error || failedFactuality || failedToolUsage) {
         const messages: string[] = [];
         if (r.error) {
           messages.push(r.error?.toString());
         }
-        if (failedFactuality) {
-          messages.push(
-            `Factuality score ${factualityScore} is below threshold ${factualityPassCutoff}.`
-          );
-        }
-        if (failedToolUsage) {
-          messages.push(
-            `Tool Usage score ${toolUsageScore} is below threshold ${toolUsagePassCutoff}.`
-          );
-        }
-        testCase.failure(messages.join('\n'));
-      }
 
-      printResultsTable({
-        factualityScore,
-        toolUsageScore,
-        thresholds: r.metadata.thresholds,
-        testName: r.metadata.testName,
+        const scoreErrors = calculateScores(
+          r.scores,
+          r.metadata.scoreThresholds
+        );
+        messages.push(...scoreErrors);
+
+        if (messages.length > 0) {
+          testCase.failure(messages.join('\n'));
+        }
+
+        printResults(r.scores, r.metadata.scoreThresholds, r.metadata.testName);
       });
-    });
 
-    // Report any errors that occurred.
-    const failingResults = results.filter(
-      (r: { error: unknown }) => r.error !== undefined
-    );
-    if (failingResults.length > 0) {
-      reportFailures(evaluator, failingResults, { verbose, jsonl });
-    }
-    return failingResults.length === 0;
-  },
-  reportRun: async (evalReports: boolean[]) => {
-    xmlBuilder.writeTo(path.join(process.cwd(), '/bin/braintrust_evals.xml'));
-    return evalReports.every(r => r);
-  },
-});
+      // Report any errors that occurred.
+      const failingResults = results.filter(
+        (r: { error: unknown }) => r.error !== undefined
+      );
+      if (failingResults.length > 0) {
+        reportFailures(evaluator, failingResults, { verbose, jsonl });
+      }
+      return failingResults.length === 0;
+    },
+    reportRun: async (evalReports: boolean[]) => {
+      xmlBuilder.writeTo(
+        path.join(process.cwd(), `/bin/${xmlFileOutputName}.xml`)
+      );
+      return evalReports.every(r => r);
+    },
+  });
 
-const printResultsTable = ({
-  factualityScore,
-  testName,
-  thresholds,
-  toolUsageScore,
-}: {
-  factualityScore: number;
-  toolUsageScore: number;
-  thresholds: Thresholds;
-  testName: string;
-}) => {
-  const resultsTable = {
-    Factuality: {
-      actual: factualityScore,
-      expected: `>= ${thresholds.factuality}`,
-    },
-    'Tool Usage': {
-      actual: toolUsageScore,
-      expected: `>= ${thresholds.toolUsage}`,
-    },
-  };
-  console.log(testName);
-  console.table(resultsTable);
+  return reporter;
 };

--- a/src/evals/scorers.ts
+++ b/src/evals/scorers.ts
@@ -1,27 +1,23 @@
-import { TestInput, TestResult } from './types';
-
 // https://www.braintrust.dev/docs/guides/experiments/write#define-your-own-scorers
+// See existing scorers at https://github.com/braintrustdata/autoevals/blob/main/js/manifest.ts.
 
 /**
  * This custom scorer evaluates whether the correct tools were used in the evaluation.
  * @param args - Object containing the following:
- * @param args.input - Input (originally given in test case)
  * @param args.output - Output from LLM
  * @param args.expected - Expected (originally given in test case)
  * @returns score (1 being correct, 0 being incorrect) along with metadata
  */
-export const toolUsage = (args: {
-  input: TestInput;
-  output: TestResult;
-  expected: TestResult;
-}) => {
-  const expectedTools = args.expected.toolsUsed;
-  const actualTools = args.output.toolsUsed;
-  const correctToolsUsed = expectedTools.every(tool =>
-    actualTools.includes(tool)
-  );
+export const toolUsage = (args: { output: string[]; expected: string[] }) => {
+  const expectedTools = args.expected;
+  const actualTools = args.output;
+
+  const correctToolsUsed: boolean =
+    expectedTools.length === actualTools.length &&
+    expectedTools.every(tool => actualTools.includes(tool));
+
   return {
-    name: 'Tool Usage',
+    name: 'ToolUsage',
     score: correctToolsUsed ? 1 : 0,
     metadata: {
       expected_tools: expectedTools,

--- a/src/evals/tracer.ts
+++ b/src/evals/tracer.ts
@@ -7,7 +7,9 @@ import { ModelOutput } from './types';
  * @param callModel - function to call the given agent
  * @returns Expected result from calling agent
  */
-export const callModelWithTrace = async (callModel: () => ModelOutput) =>
+export const callModelWithTrace = async <Input, Output>(
+  callModel: () => ModelOutput<Input, Output>
+) =>
   traced(async span => {
     span.setAttributes({ name: 'call-model-span' });
 

--- a/src/evals/types.ts
+++ b/src/evals/types.ts
@@ -1,53 +1,21 @@
-import { MastraModelOutput, OutputSchema } from '@mastra/core/dist/stream';
+import { AISDKV5OutputStream, OutputSchema } from '@mastra/core/dist/stream';
 
-/**
- * These are the users declared in the local Evergreen database.
- */
-export enum TestUser {
-  Regular = 'regular',
-  Privileged = 'privileged',
-  Admin = 'admin',
-}
-
-export type TestInput = {
-  content: string;
-  user: TestUser;
-};
-
-export type Thresholds = {
-  factuality: number;
-  toolUsage: number;
-};
-
-export type TestMetadata = {
-  description: string;
-  testName: string;
-  thresholds: Thresholds;
-};
-
-export type TestResult = {
-  text: string;
-  toolsUsed: string[];
-};
-
-export type TestCase = {
-  input: TestInput;
-  expected: TestResult;
-  metadata: TestMetadata;
-};
-
-type MastraAgentOutput = Awaited<
-  ReturnType<MastraModelOutput<OutputSchema>['getFullOutput']>
+export type MastraAgentOutput = Awaited<
+  ReturnType<AISDKV5OutputStream<OutputSchema>['getFullOutput']>
 >;
 
-export type ModelOutput = Promise<
-  MastraAgentOutput & { input: TestInput; output: TestResult }
+export type ModelOutput<Input, Output> = Promise<
+  MastraAgentOutput & { input: Input; output: Output }
 >;
 
-export interface CustomEvalResult {
-  input: TestInput;
-  output: TestResult & { duration: number };
-  metadata: TestMetadata;
-  scores: Record<string, number>;
+export interface ReporterEvalResult<Input, Output, Metadata, Scores> {
+  input: Input;
+  output: Output & { duration: number };
+  metadata: Metadata & {
+    description: string;
+    testName: string;
+    scoreThresholds: Scores;
+  };
+  scores: Scores;
   error?: Error;
 }

--- a/src/mastra/agents/constants.ts
+++ b/src/mastra/agents/constants.ts
@@ -5,5 +5,12 @@
 const USER_ID = 'userId';
 
 const EVERGREEN_AGENT_NAME = 'evergreenAgent';
+const QUESTION_CLASSIFIER_AGENT_NAME = 'questionClassifierAgent';
+const SAGE_THINKING_AGENT_NAME = 'sageThinkingAgent';
 
-export { USER_ID, EVERGREEN_AGENT_NAME };
+export {
+  USER_ID,
+  EVERGREEN_AGENT_NAME,
+  QUESTION_CLASSIFIER_AGENT_NAME,
+  SAGE_THINKING_AGENT_NAME,
+};


### PR DESCRIPTION
DEVPROD-21433

### Description
Cleans up eval code by making functions more generic and reuseable across test suites. 
* Add tests for question classifier agent
* Use `format: 'aisdk'` when generating model responses
* Fixed Tool Usage scorer that didn't properly throw an error when the `expectedTools` or `actualTools` were empty arrays.
* Adds wrapper script that checks if `yarn eval` threw any compile errors. This is to prevent unexpected breakage in the future.
* Adds `README` for evals

Will add tests for Sage Thinking Agent in follow up PR.


