### PR TITLE
DEVPROD-22503 Fix sage production server crash

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -43,6 +43,7 @@ buildvariants:
       - name: question-classifier-evals
       - name: log-analyzer-workflow-evals
       - name: check-mastra-dev-startup
+      - name: check-sage-prod-startup
     display_tasks:
       - name: evals
         execution_tasks:
@@ -100,6 +101,7 @@ tasks:
           xml_file_name: log_analyzer_workflow_evals.xml
   - name: check-mastra-dev-startup
     commands:
+      - func: yarn-build
       - func: mastra-dev-startup
 
 functions:
@@ -337,3 +339,12 @@ functions:
       script: |
         ${PREPARE_SHELL}
         ./scripts/mastra-dev-startup.sh
+
+  check-sage-prod-startup:
+    command: shell.exec
+    params:
+      working_dir: sage
+      shell: bash
+      script: |
+        ${PREPARE_SHELL}
+        ./scripts/sage-prod-startup.sh

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "description": "evergreen-ai-service",
   "main": "dist/main.js",
-  "type": "module",
   "scripts": {
     "build": "tsc && tsc-alias",
     "start": "NODE_ENV=production node dist/main.js",

--- a/scripts/sage-prod-startup.sh
+++ b/scripts/sage-prod-startup.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -e
+
+check_for_errors() {
+    local log_file="$1"
+    if grep -E "Error|triggerUncaughtException|Failed to start" "$log_file"; then
+        echo "Errors detected during Sage prod server startup"
+        echo "Check for configuration or startup issues"
+        return 1
+    fi
+}
+
+# Capture server output to a log file and terminal
+log_file=$(mktemp)
+echo "Starting Sage prod server..."
+timeout 30 yarn start 2>&1 | tee "$log_file" &
+server_pid=$!
+
+# Wait for server to start or timeout
+sleep 10
+
+# Check if process is still running
+if ! kill -0 $server_pid 2>/dev/null; then
+    echo "Sage prod server failed to start"
+    cat "$log_file"
+    rm "$log_file"
+    exit 1
+fi
+
+# Check for errors
+if ! check_for_errors "$log_file"; then
+    # Errors found
+    kill $server_pid
+    rm "$log_file"
+    exit 1
+else
+    # No errors, clean up
+    kill $server_pid
+    rm "$log_file"
+    exit 0
+fi

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "Node",
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "module": "commonjs",
+    "lib": ["ESNext"],
     "outDir": "./dist",
     "baseUrl": "src",
+    "rootDir": "src",
     "strict": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -24,6 +24,6 @@
     "noImplicitOverride": true,
     "types": ["vitest/globals"]
   },
-  "include": ["src", "vite.config.ts"],
+  "include": ["src"],
   "exclude": ["node_modules", "dist", ".mastra"]
 }


### PR DESCRIPTION
DEVPROD-22503

### Description

Due to a change introduced in https://github.com/evergreen-ci/sage/commit/545f6695b3066b0cf68a3c00eded9e4d8c235433#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519. The sage server produced by `yarn build` would not startup. This was causing staging deploys to crash loop. 

### Testing
Sage now runs after deploying
<img width="720" height="19" alt="image" src="https://github.com/user-attachments/assets/428a3c41-6983-48cb-bcdf-afd0ee0b8c98" />
