### PR TITLE
DEVPROD-22706 Add resource and replica autoscaling to sage

### DIFF
--- a/environments/prod.yaml
+++ b/environments/prod.yaml
@@ -1,3 +1,5 @@
+replicaCount: 2
+
 arch: "amd64"
 
 ingress:
@@ -51,3 +53,14 @@ envSecrets:
 
 serviceAccount:
   enabled: true
+
+autoscaling:
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80

--- a/environments/prod.yaml
+++ b/environments/prod.yaml
@@ -53,7 +53,7 @@ serviceAccount:
   enabled: true
 
 autoscaling:
-  minReplicas: 1
+  minReplicas: 2
   maxReplicas: 5
   metrics:
     - type: Resource

--- a/environments/prod.yaml
+++ b/environments/prod.yaml
@@ -1,5 +1,3 @@
-replicaCount: 2
-
 arch: "amd64"
 
 ingress:


### PR DESCRIPTION
DEVPROD-22706

### Description

Sage experienced an outage due to maxing CPU usage. It currently runs on only one replica with no potential for autoscaling so we should introduce autoscaling to allow it to be more flexible in the face of traffic.

https://kanopy.corp.mongodb.com/docs/production/application_resources/#horizontal-pod-autoscaler
